### PR TITLE
Feature/Cache key improvements

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,43 +1,41 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "CwlCatchException",
-        "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
-        "state": {
-          "branch": null,
-          "revision": "f809deb30dc5c9d9b78c872e553261a61177721a",
-          "version": "2.0.0"
-        }
-      },
-      {
-        "package": "CwlPreconditionTesting",
-        "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
-        "state": {
-          "branch": null,
-          "revision": "02b7a39a99c4da27abe03cab2053a9034379639f",
-          "version": "2.0.0"
-        }
-      },
-      {
-        "package": "Nimble",
-        "repositoryURL": "https://github.com/Quick/Nimble.git",
-        "state": {
-          "branch": null,
-          "revision": "e491a6731307bb23783bf664d003be9b2fa59ab5",
-          "version": "9.0.0"
-        }
-      },
-      {
-        "package": "SafeCollection",
-        "repositoryURL": "https://github.com/devxoul/SafeCollection.git",
-        "state": {
-          "branch": null,
-          "revision": "8ddc40807b203b731a30c3dfd4deb978967d948b",
-          "version": "3.1.0"
-        }
+  "pins" : [
+    {
+      "identity" : "gcdwebserver",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SlaunchaMan/GCDWebServer.git",
+      "state" : {
+        "branch" : "swift-package-manager",
+        "revision" : "935e2736044e71e5341663c3cc9a335ba6867a2b"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "pincache",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pinterest/PINCache.git",
+      "state" : {
+        "revision" : "875c654984fb52b47ca65ae70d24852b0003ccd9",
+        "version" : "3.0.3"
+      }
+    },
+    {
+      "identity" : "pinoperation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pinterest/PINOperation.git",
+      "state" : {
+        "revision" : "40504c156a68b20f98f7ddc73a115cbb7893be25",
+        "version" : "1.2.2"
+      }
+    },
+    {
+      "identity" : "safecollection",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/devxoul/SafeCollection.git",
+      "state" : {
+        "revision" : "8ddc40807b203b731a30c3dfd4deb978967d948b",
+        "version" : "3.1.0"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
   name: "HLSCachingReverseProxyServer",
   platforms: [
-    .macOS(.v10_13), .iOS(.v11), .tvOS(.v11)
+    .macOS(.v10_15), .iOS(.v11), .tvOS(.v11)
   ],
   products: [
     .library(name: "HLSCachingReverseProxyServer", targets: ["HLSCachingReverseProxyServer"]),

--- a/Package.swift
+++ b/Package.swift
@@ -1,11 +1,11 @@
-// swift-tools-version:5.1
+// swift-tools-version: 5.7
 
 import PackageDescription
 
 let package = Package(
   name: "HLSCachingReverseProxyServer",
   platforms: [
-    .macOS(.v10_11), .iOS(.v9), .tvOS(.v9)
+    .macOS(.v10_13), .iOS(.v11), .tvOS(.v11)
   ],
   products: [
     .library(name: "HLSCachingReverseProxyServer", targets: ["HLSCachingReverseProxyServer"]),

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
   name: "HLSCachingReverseProxyServer",
   platforms: [
-    .macOS(.v10_15), .iOS(.v11), .tvOS(.v11)
+    .iOS(.v11), .tvOS(.v11)
   ],
   products: [
     .library(name: "HLSCachingReverseProxyServer", targets: ["HLSCachingReverseProxyServer"]),

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
   name: "HLSCachingReverseProxyServer",
   platforms: [
-    .iOS(.v11), .tvOS(.v11)
+    .iOS(.v13)
   ],
   products: [
     .library(name: "HLSCachingReverseProxyServer", targets: ["HLSCachingReverseProxyServer"]),

--- a/Package.swift
+++ b/Package.swift
@@ -11,10 +11,12 @@ let package = Package(
     .library(name: "HLSCachingReverseProxyServer", targets: ["HLSCachingReverseProxyServer"]),
   ],
   dependencies: [
+    .package(url: "https://github.com/SlaunchaMan/GCDWebServer.git", branch: "swift-package-manager"),
+    .package(url: "https://github.com/pinterest/PINCache.git", .upToNextMinor(from: "3.0.0")),
     .package(url: "https://github.com/devxoul/SafeCollection.git", .upToNextMajor(from: "3.1.0")),
   ],
   targets: [
     .target(name: "HLSCachingReverseProxyServer"),
-    .testTarget(name: "HLSCachingReverseProxyServerTests", dependencies: ["HLSCachingReverseProxyServer", "SafeCollection"]),
+    .testTarget(name: "HLSCachingReverseProxyServerTests", dependencies: ["HLSCachingReverseProxyServer", "GCDWebServer", "PINCache", "SafeCollection"]),
   ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -11,11 +11,10 @@ let package = Package(
     .library(name: "HLSCachingReverseProxyServer", targets: ["HLSCachingReverseProxyServer"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "9.0.0")),
     .package(url: "https://github.com/devxoul/SafeCollection.git", .upToNextMajor(from: "3.1.0")),
   ],
   targets: [
     .target(name: "HLSCachingReverseProxyServer"),
-    .testTarget(name: "HLSCachingReverseProxyServerTests", dependencies: ["HLSCachingReverseProxyServer", "Nimble", "SafeCollection"]),
+    .testTarget(name: "HLSCachingReverseProxyServerTests", dependencies: ["HLSCachingReverseProxyServer", "SafeCollection"]),
   ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     .package(url: "https://github.com/devxoul/SafeCollection.git", .upToNextMajor(from: "3.1.0")),
   ],
   targets: [
-    .target(name: "HLSCachingReverseProxyServer"),
-    .testTarget(name: "HLSCachingReverseProxyServerTests", dependencies: ["HLSCachingReverseProxyServer", "GCDWebServer", "PINCache", "SafeCollection"]),
+    .target(name: "HLSCachingReverseProxyServer", dependencies: ["GCDWebServer", "PINCache"]),
+    .testTarget(name: "HLSCachingReverseProxyServerTests", dependencies: ["HLSCachingReverseProxyServer", "SafeCollection"]),
   ]
 )

--- a/Sources/HLSCachingReverseProxyServer/HLSCachingReverseProxyServer.swift
+++ b/Sources/HLSCachingReverseProxyServer/HLSCachingReverseProxyServer.swift
@@ -206,7 +206,7 @@ open class HLSCachingReverseProxyServer {
         }
     }
 
-    private func cacheKey(for resourceURL: URL) -> String {
+    func cacheKey(for resourceURL: URL) -> String {
         let urlWithoutPattern = removePattern(for: resourceURL)
         let md5 = MD5(string: urlWithoutPattern)
         return "\(md5)_\(resourceURL.lastPathComponent)"

--- a/Sources/HLSCachingReverseProxyServer/HLSCachingReverseProxyServer.swift
+++ b/Sources/HLSCachingReverseProxyServer/HLSCachingReverseProxyServer.swift
@@ -1,126 +1,127 @@
 import GCDWebServer
 import PINCache
+import CryptoKit
 
 open class HLSCachingReverseProxyServer {
     static let originURLKey = "__hls_origin_url"
-    
+
     private let webServer: GCDWebServer
     private let urlSession: URLSession
     private let cache: PINCaching
-    
+
     private(set) var port: Int?
-    
+
     public init(webServer: GCDWebServer, urlSession: URLSession, cache: PINCaching) {
         self.webServer = webServer
         self.urlSession = urlSession
         self.cache = cache
-        
+
         self.addRequestHandlers()
     }
-    
-    
+
+
     // MARK: Starting and Stopping Server
-    
+
     open func start(port: UInt) {
         guard !self.webServer.isRunning else { return }
         self.port = Int(port)
         self.webServer.start(withPort: port, bonjourName: nil)
     }
-    
+
     open func stop() {
         guard self.webServer.isRunning else { return }
         self.port = nil
         self.webServer.stop()
     }
-    
-    
+
+
     // MARK: Resource URL
-    
+
     open func reverseProxyURL(from originURL: URL) -> URL? {
         guard let port = self.port else { return nil }
-        
+
         guard var components = URLComponents(url: originURL, resolvingAgainstBaseURL: false) else { return nil }
         components.scheme = "http"
         components.host = "127.0.0.1"
         components.port = port
-        
+
         let originURLQueryItem = URLQueryItem(name: Self.originURLKey, value: originURL.absoluteString)
         components.queryItems = (components.queryItems ?? []) + [originURLQueryItem]
-        
+
         return components.url
     }
-    
-    
+
+
     // MARK: Request Handler
-    
+
     private func addRequestHandlers() {
         self.addPlaylistHandler()
         self.addSegmentHandler()
     }
-    
+
     private func addPlaylistHandler() {
         self.webServer.addHandler(forMethod: "GET", pathRegex: "^/.*\\.m3u8$", request: GCDWebServerRequest.self) { [weak self] request, completion in
             guard let self = self else {
                 return completion(GCDWebServerDataResponse(statusCode: 500))
             }
-            
+
             guard let originURL = self.originURL(from: request) else {
                 return completion(GCDWebServerErrorResponse(statusCode: 400))
             }
-            
+
             let task = self.urlSession.dataTask(with: originURL) { data, response, error in
                 guard let data = data, let response = response else {
                     return completion(GCDWebServerErrorResponse(statusCode: 500))
                 }
-                
+
                 let playlistData = self.reverseProxyPlaylist(with: data, forOriginURL: originURL)
                 let contentType = response.mimeType ?? "application/x-mpegurl"
                 completion(GCDWebServerDataResponse(data: playlistData, contentType: contentType))
             }
-            
+
             task.resume()
         }
     }
-    
+
     private func addSegmentHandler() {
         self.webServer.addHandler(forMethod: "GET", pathRegex: "^/.*\\.ts$", request: GCDWebServerRequest.self) { [weak self] request, completion in
             guard let self = self else {
                 return completion(GCDWebServerDataResponse(statusCode: 500))
             }
-            
+
             guard let originURL = self.originURL(from: request) else {
                 return completion(GCDWebServerErrorResponse(statusCode: 400))
             }
-            
+
             if let cachedData = self.cachedData(for: originURL) {
                 return completion(GCDWebServerDataResponse(data: cachedData, contentType: "video/mp2t"))
             }
-            
+
             let task = self.urlSession.dataTask(with: originURL) { data, response, error in
                 guard let data = data, let response = response else {
                     return completion(GCDWebServerErrorResponse(statusCode: 500))
                 }
-                
+
                 let contentType = response.mimeType ?? "video/mp2t"
                 completion(GCDWebServerDataResponse(data: data, contentType: contentType))
-                
+
                 self.saveCacheData(data, for: originURL)
             }
-            
+
             task.resume()
         }
     }
-    
+
     private func originURL(from request: GCDWebServerRequest) -> URL? {
         guard let encodedURLString = request.query?[Self.originURLKey] else { return nil }
         guard let urlString = encodedURLString.removingPercentEncoding else { return nil }
         let url = URL(string: urlString)
         return url
     }
-    
-    
+
+
     // MARK: Manipulating Playlist
-    
+
     private func reverseProxyPlaylist(with data: Data, forOriginURL originURL: URL) -> Data {
         return String(data: data, encoding: .utf8)!
             .components(separatedBy: .newlines)
@@ -128,67 +129,75 @@ open class HLSCachingReverseProxyServer {
             .joined(separator: "\n")
             .data(using: .utf8)!
     }
-    
+
     private func processPlaylistLine(_ line: String, forOriginURL originURL: URL) -> String {
         guard !line.isEmpty else { return line }
-        
+
         if line.hasPrefix("#") {
             return self.lineByReplacingURI(line: line, forOriginURL: originURL)
         }
-        
+
         if let originalSegmentURL = self.absoluteURL(from: line, forOriginURL: originURL),
            let reverseProxyURL = self.reverseProxyURL(from: originalSegmentURL) {
             return reverseProxyURL.absoluteString
         }
-        
+
         return line
     }
-    
+
     private func lineByReplacingURI(line: String, forOriginURL originURL: URL) -> String {
         let uriPattern = try! NSRegularExpression(pattern: "URI=\"(.*)\"")
         let lineRange = NSMakeRange(0, line.count)
         guard let result = uriPattern.firstMatch(in: line, options: [], range: lineRange) else { return line }
-        
+
         let uri = (line as NSString).substring(with: result.range(at: 1))
         guard let absoluteURL = self.absoluteURL(from: uri, forOriginURL: originURL) else { return line }
         guard let reverseProxyURL = self.reverseProxyURL(from: absoluteURL) else { return line }
-        
+
         return uriPattern.stringByReplacingMatches(in: line, options: [], range: lineRange, withTemplate: "URI=\"\(reverseProxyURL.absoluteString)\"")
     }
-    
+
     private func absoluteURL(from line: String, forOriginURL originURL: URL) -> URL? {
         guard ["m3u8", "ts"].contains(originURL.pathExtension) else { return nil }
-        
+
         if line.hasPrefix("http://") || line.hasPrefix("https://") {
             return URL(string: line)
         }
-        
+
         guard let scheme = originURL.scheme, let host = originURL.host else { return nil }
-        
+
         let path: String
         if line.hasPrefix("/") {
             path = line
         } else {
             path = originURL.deletingLastPathComponent().appendingPathComponent(line).path
         }
-        
+
         return URL(string: scheme + "://" + host + path)?.standardized
     }
-    
-    
+
+
     // MARK: Caching
-    
+
     private func cachedData(for resourceURL: URL) -> Data? {
         let key = self.cacheKey(for: resourceURL)
         return self.cache.object(forKey: key) as? Data
     }
-    
+
     private func saveCacheData(_ data: Data, for resourceURL: URL) {
         let key = self.cacheKey(for: resourceURL)
         self.cache.setObject(data, forKey: key)
     }
-    
+
+    private func MD5(string: String) -> String {
+        let digest = Insecure.MD5.hash(data: Data(string.utf8))
+
+        return digest.map {
+            String(format: "%02hhx", $0)
+        }.joined()
+    }
+
     private func cacheKey(for resourceURL: URL) -> String {
-        return resourceURL.absoluteString.data(using: .utf8)!.base64EncodedString()
+        return MD5(string: resourceURL.absoluteString)
     }
 }

--- a/Sources/HLSCachingReverseProxyServer/HLSCachingReverseProxyServer.swift
+++ b/Sources/HLSCachingReverseProxyServer/HLSCachingReverseProxyServer.swift
@@ -11,7 +11,7 @@ open class HLSCachingReverseProxyServer {
 
     private(set) var port: Int?
 
-    open var transformUrlForCacheKey: ((URL) -> String)?
+    open var cacheKeyHandler: ((URL) -> String)?
 
     public init(webServer: GCDWebServer, urlSession: URLSession, cache: PINCaching) {
         self.webServer = webServer
@@ -200,8 +200,6 @@ open class HLSCachingReverseProxyServer {
     }
 
     private func cacheKey(for resourceURL: URL) -> String {
-        let urlString = transformUrlForCacheKey?(resourceURL) ?? resourceURL.absoluteString
-        let md5 = MD5(string: urlString)
-        return "\(md5)_\(resourceURL.lastPathComponent)"
+        cacheKeyHandler?(resourceURL) ?? MD5(string: resourceURL.absoluteString)
     }
 }

--- a/Sources/HLSCachingReverseProxyServer/HLSCachingReverseProxyServer.swift
+++ b/Sources/HLSCachingReverseProxyServer/HLSCachingReverseProxyServer.swift
@@ -10,7 +10,8 @@ open class HLSCachingReverseProxyServer {
     private let cache: PINCaching
 
     private(set) var port: Int?
-    private var transformUrlForCacheKey: ((URL) -> String)?
+
+    open var transformUrlForCacheKey: ((URL) -> String)?
 
     public init(webServer: GCDWebServer, urlSession: URLSession, cache: PINCaching) {
         self.webServer = webServer
@@ -50,12 +51,6 @@ open class HLSCachingReverseProxyServer {
         components.queryItems = (components.queryItems ?? []) + [originURLQueryItem]
 
         return components.url
-    }
-
-    // MARK: Configuration
-
-    open func configureCache(with transformUrlForCacheKey: @escaping ((URL) -> String)) {
-        self.transformUrlForCacheKey = transformUrlForCacheKey
     }
 
 

--- a/Sources/HLSCachingReverseProxyServer/HLSCachingReverseProxyServer.swift
+++ b/Sources/HLSCachingReverseProxyServer/HLSCachingReverseProxyServer.swift
@@ -206,7 +206,7 @@ open class HLSCachingReverseProxyServer {
         }
     }
 
-    func cacheKey(for resourceURL: URL) -> String {
+    open func cacheKey(for resourceURL: URL) -> String {
         let urlWithoutPattern = removePattern(for: resourceURL)
         let md5 = MD5(string: urlWithoutPattern)
         return "\(md5)_\(resourceURL.lastPathComponent)"

--- a/Sources/HLSCachingReverseProxyServer/HLSCachingReverseProxyServer.swift
+++ b/Sources/HLSCachingReverseProxyServer/HLSCachingReverseProxyServer.swift
@@ -184,7 +184,7 @@ open class HLSCachingReverseProxyServer {
         return self.cache.object(forKey: key) as? Data
     }
 
-    open func saveCacheData(_ data: Data, for resourceURL: URL) {
+    private func saveCacheData(_ data: Data, for resourceURL: URL) {
         let key = self.cacheKey(for: resourceURL)
         self.cache.setObject(data, forKey: key)
     }

--- a/Sources/HLSCachingReverseProxyServer/HLSCachingReverseProxyServer.swift
+++ b/Sources/HLSCachingReverseProxyServer/HLSCachingReverseProxyServer.swift
@@ -197,7 +197,18 @@ open class HLSCachingReverseProxyServer {
         }.joined()
     }
 
+    private func removePattern(for resourceURL: URL) -> String {
+        let pattern = "video/(.*?)/seg"
+        if let range = resourceURL.path.range(of: pattern, options: .regularExpression) {
+            return resourceURL.path.replacingCharacters(in: range, with: "")
+        } else {
+            return resourceURL.absoluteString
+        }
+    }
+
     private func cacheKey(for resourceURL: URL) -> String {
-        return MD5(string: resourceURL.absoluteString)
+        let urlWithoutPattern = removePattern(for: resourceURL)
+        let md5 = MD5(string: urlWithoutPattern)
+        return "\(md5)_\(resourceURL.lastPathComponent)"
     }
 }

--- a/Sources/HLSCachingReverseProxyServer/HLSCachingReverseProxyServer.swift
+++ b/Sources/HLSCachingReverseProxyServer/HLSCachingReverseProxyServer.swift
@@ -184,7 +184,7 @@ open class HLSCachingReverseProxyServer {
         return self.cache.object(forKey: key) as? Data
     }
 
-    private func saveCacheData(_ data: Data, for resourceURL: URL) {
+    open func saveCacheData(_ data: Data, for resourceURL: URL) {
         let key = self.cacheKey(for: resourceURL)
         self.cache.setObject(data, forKey: key)
     }
@@ -206,7 +206,7 @@ open class HLSCachingReverseProxyServer {
         }
     }
 
-    open func cacheKey(for resourceURL: URL) -> String {
+    private func cacheKey(for resourceURL: URL) -> String {
         let urlWithoutPattern = removePattern(for: resourceURL)
         let md5 = MD5(string: urlWithoutPattern)
         return "\(md5)_\(resourceURL.lastPathComponent)"

--- a/Sources/HLSCachingReverseProxyServer/HLSCachingReverseProxyServer.swift
+++ b/Sources/HLSCachingReverseProxyServer/HLSCachingReverseProxyServer.swift
@@ -11,7 +11,7 @@ open class HLSCachingReverseProxyServer {
 
     private(set) var port: Int?
 
-    open var cacheKeyHandler: ((URL) -> String)?
+    open var cacheKeyHandler: ((URL) -> String?)?
 
     public init(webServer: GCDWebServer, urlSession: URLSession, cache: PINCaching) {
         self.webServer = webServer

--- a/Sources/HLSCachingReverseProxyServer/HLSCachingReverseProxyServer.swift
+++ b/Sources/HLSCachingReverseProxyServer/HLSCachingReverseProxyServer.swift
@@ -2,193 +2,193 @@ import GCDWebServer
 import PINCache
 
 open class HLSCachingReverseProxyServer {
-  static let originURLKey = "__hls_origin_url"
-
-  private let webServer: GCDWebServer
-  private let urlSession: URLSession
-  private let cache: PINCaching
-
-  private(set) var port: Int?
-
-  public init(webServer: GCDWebServer, urlSession: URLSession, cache: PINCaching) {
-    self.webServer = webServer
-    self.urlSession = urlSession
-    self.cache = cache
-
-    self.addRequestHandlers()
-  }
-
-
-  // MARK: Starting and Stopping Server
-
-  open func start(port: UInt) {
-    guard !self.webServer.isRunning else { return }
-    self.port = Int(port)
-    self.webServer.start(withPort: port, bonjourName: nil)
-  }
-
-  open func stop() {
-    guard self.webServer.isRunning else { return }
-    self.port = nil
-    self.webServer.stop()
-  }
-
-
-  // MARK: Resource URL
-
-  open func reverseProxyURL(from originURL: URL) -> URL? {
-    guard let port = self.port else { return nil }
-
-    guard var components = URLComponents(url: originURL, resolvingAgainstBaseURL: false) else { return nil }
-    components.scheme = "http"
-    components.host = "127.0.0.1"
-    components.port = port
-
-    let originURLQueryItem = URLQueryItem(name: Self.originURLKey, value: originURL.absoluteString)
-    components.queryItems = (components.queryItems ?? []) + [originURLQueryItem]
-
-    return components.url
-  }
-
-
-  // MARK: Request Handler
-
-  private func addRequestHandlers() {
-    self.addPlaylistHandler()
-    self.addSegmentHandler()
-  }
-
-  private func addPlaylistHandler() {
-    self.webServer.addHandler(forMethod: "GET", pathRegex: "^/.*\\.m3u8$", request: GCDWebServerRequest.self) { [weak self] request, completion in
-      guard let self = self else {
-        return completion(GCDWebServerDataResponse(statusCode: 500))
-      }
-
-      guard let originURL = self.originURL(from: request) else {
-        return completion(GCDWebServerErrorResponse(statusCode: 400))
-      }
-
-      let task = self.urlSession.dataTask(with: originURL) { data, response, error in
-        guard let data = data, let response = response else {
-          return completion(GCDWebServerErrorResponse(statusCode: 500))
+    static let originURLKey = "__hls_origin_url"
+    
+    private let webServer: GCDWebServer
+    private let urlSession: URLSession
+    private let cache: PINCaching
+    
+    private(set) var port: Int?
+    
+    public init(webServer: GCDWebServer, urlSession: URLSession, cache: PINCaching) {
+        self.webServer = webServer
+        self.urlSession = urlSession
+        self.cache = cache
+        
+        self.addRequestHandlers()
+    }
+    
+    
+    // MARK: Starting and Stopping Server
+    
+    open func start(port: UInt) {
+        guard !self.webServer.isRunning else { return }
+        self.port = Int(port)
+        self.webServer.start(withPort: port, bonjourName: nil)
+    }
+    
+    open func stop() {
+        guard self.webServer.isRunning else { return }
+        self.port = nil
+        self.webServer.stop()
+    }
+    
+    
+    // MARK: Resource URL
+    
+    open func reverseProxyURL(from originURL: URL) -> URL? {
+        guard let port = self.port else { return nil }
+        
+        guard var components = URLComponents(url: originURL, resolvingAgainstBaseURL: false) else { return nil }
+        components.scheme = "http"
+        components.host = "127.0.0.1"
+        components.port = port
+        
+        let originURLQueryItem = URLQueryItem(name: Self.originURLKey, value: originURL.absoluteString)
+        components.queryItems = (components.queryItems ?? []) + [originURLQueryItem]
+        
+        return components.url
+    }
+    
+    
+    // MARK: Request Handler
+    
+    private func addRequestHandlers() {
+        self.addPlaylistHandler()
+        self.addSegmentHandler()
+    }
+    
+    private func addPlaylistHandler() {
+        self.webServer.addHandler(forMethod: "GET", pathRegex: "^/.*\\.m3u8$", request: GCDWebServerRequest.self) { [weak self] request, completion in
+            guard let self = self else {
+                return completion(GCDWebServerDataResponse(statusCode: 500))
+            }
+            
+            guard let originURL = self.originURL(from: request) else {
+                return completion(GCDWebServerErrorResponse(statusCode: 400))
+            }
+            
+            let task = self.urlSession.dataTask(with: originURL) { data, response, error in
+                guard let data = data, let response = response else {
+                    return completion(GCDWebServerErrorResponse(statusCode: 500))
+                }
+                
+                let playlistData = self.reverseProxyPlaylist(with: data, forOriginURL: originURL)
+                let contentType = response.mimeType ?? "application/x-mpegurl"
+                completion(GCDWebServerDataResponse(data: playlistData, contentType: contentType))
+            }
+            
+            task.resume()
         }
-
-        let playlistData = self.reverseProxyPlaylist(with: data, forOriginURL: originURL)
-        let contentType = response.mimeType ?? "application/x-mpegurl"
-        completion(GCDWebServerDataResponse(data: playlistData, contentType: contentType))
-      }
-
-      task.resume()
     }
-  }
-
-  private func addSegmentHandler() {
-    self.webServer.addHandler(forMethod: "GET", pathRegex: "^/.*\\.ts$", request: GCDWebServerRequest.self) { [weak self] request, completion in
-      guard let self = self else {
-        return completion(GCDWebServerDataResponse(statusCode: 500))
-      }
-
-      guard let originURL = self.originURL(from: request) else {
-        return completion(GCDWebServerErrorResponse(statusCode: 400))
-      }
-
-      if let cachedData = self.cachedData(for: originURL) {
-        return completion(GCDWebServerDataResponse(data: cachedData, contentType: "video/mp2t"))
-      }
-
-      let task = self.urlSession.dataTask(with: originURL) { data, response, error in
-        guard let data = data, let response = response else {
-          return completion(GCDWebServerErrorResponse(statusCode: 500))
+    
+    private func addSegmentHandler() {
+        self.webServer.addHandler(forMethod: "GET", pathRegex: "^/.*\\.ts$", request: GCDWebServerRequest.self) { [weak self] request, completion in
+            guard let self = self else {
+                return completion(GCDWebServerDataResponse(statusCode: 500))
+            }
+            
+            guard let originURL = self.originURL(from: request) else {
+                return completion(GCDWebServerErrorResponse(statusCode: 400))
+            }
+            
+            if let cachedData = self.cachedData(for: originURL) {
+                return completion(GCDWebServerDataResponse(data: cachedData, contentType: "video/mp2t"))
+            }
+            
+            let task = self.urlSession.dataTask(with: originURL) { data, response, error in
+                guard let data = data, let response = response else {
+                    return completion(GCDWebServerErrorResponse(statusCode: 500))
+                }
+                
+                let contentType = response.mimeType ?? "video/mp2t"
+                completion(GCDWebServerDataResponse(data: data, contentType: contentType))
+                
+                self.saveCacheData(data, for: originURL)
+            }
+            
+            task.resume()
         }
-
-        let contentType = response.mimeType ?? "video/mp2t"
-        completion(GCDWebServerDataResponse(data: data, contentType: contentType))
-
-        self.saveCacheData(data, for: originURL)
-      }
-
-      task.resume()
     }
-  }
-
-  private func originURL(from request: GCDWebServerRequest) -> URL? {
-    guard let encodedURLString = request.query?[Self.originURLKey] else { return nil }
-    guard let urlString = encodedURLString.removingPercentEncoding else { return nil }
-    let url = URL(string: urlString)
-    return url
-  }
-
-
-  // MARK: Manipulating Playlist
-
-  private func reverseProxyPlaylist(with data: Data, forOriginURL originURL: URL) -> Data {
-    return String(data: data, encoding: .utf8)!
-      .components(separatedBy: .newlines)
-      .map { line in self.processPlaylistLine(line, forOriginURL: originURL) }
-      .joined(separator: "\n")
-      .data(using: .utf8)!
-  }
-
-  private func processPlaylistLine(_ line: String, forOriginURL originURL: URL) -> String {
-    guard !line.isEmpty else { return line }
-
-    if line.hasPrefix("#") {
-      return self.lineByReplacingURI(line: line, forOriginURL: originURL)
+    
+    private func originURL(from request: GCDWebServerRequest) -> URL? {
+        guard let encodedURLString = request.query?[Self.originURLKey] else { return nil }
+        guard let urlString = encodedURLString.removingPercentEncoding else { return nil }
+        let url = URL(string: urlString)
+        return url
     }
-
-    if let originalSegmentURL = self.absoluteURL(from: line, forOriginURL: originURL),
-      let reverseProxyURL = self.reverseProxyURL(from: originalSegmentURL) {
-      return reverseProxyURL.absoluteString
+    
+    
+    // MARK: Manipulating Playlist
+    
+    private func reverseProxyPlaylist(with data: Data, forOriginURL originURL: URL) -> Data {
+        return String(data: data, encoding: .utf8)!
+            .components(separatedBy: .newlines)
+            .map { line in self.processPlaylistLine(line, forOriginURL: originURL) }
+            .joined(separator: "\n")
+            .data(using: .utf8)!
     }
-
-    return line
-  }
-
-  private func lineByReplacingURI(line: String, forOriginURL originURL: URL) -> String {
-    let uriPattern = try! NSRegularExpression(pattern: "URI=\"(.*)\"")
-    let lineRange = NSMakeRange(0, line.count)
-    guard let result = uriPattern.firstMatch(in: line, options: [], range: lineRange) else { return line }
-
-    let uri = (line as NSString).substring(with: result.range(at: 1))
-    guard let absoluteURL = self.absoluteURL(from: uri, forOriginURL: originURL) else { return line }
-    guard let reverseProxyURL = self.reverseProxyURL(from: absoluteURL) else { return line }
-
-    return uriPattern.stringByReplacingMatches(in: line, options: [], range: lineRange, withTemplate: "URI=\"\(reverseProxyURL.absoluteString)\"")
-  }
-
-  private func absoluteURL(from line: String, forOriginURL originURL: URL) -> URL? {
-    guard ["m3u8", "ts"].contains(originURL.pathExtension) else { return nil }
-
-    if line.hasPrefix("http://") || line.hasPrefix("https://") {
-      return URL(string: line)
+    
+    private func processPlaylistLine(_ line: String, forOriginURL originURL: URL) -> String {
+        guard !line.isEmpty else { return line }
+        
+        if line.hasPrefix("#") {
+            return self.lineByReplacingURI(line: line, forOriginURL: originURL)
+        }
+        
+        if let originalSegmentURL = self.absoluteURL(from: line, forOriginURL: originURL),
+           let reverseProxyURL = self.reverseProxyURL(from: originalSegmentURL) {
+            return reverseProxyURL.absoluteString
+        }
+        
+        return line
     }
-
-    guard let scheme = originURL.scheme, let host = originURL.host else { return nil }
-
-    let path: String
-    if line.hasPrefix("/") {
-      path = line
-    } else {
-      path = originURL.deletingLastPathComponent().appendingPathComponent(line).path
+    
+    private func lineByReplacingURI(line: String, forOriginURL originURL: URL) -> String {
+        let uriPattern = try! NSRegularExpression(pattern: "URI=\"(.*)\"")
+        let lineRange = NSMakeRange(0, line.count)
+        guard let result = uriPattern.firstMatch(in: line, options: [], range: lineRange) else { return line }
+        
+        let uri = (line as NSString).substring(with: result.range(at: 1))
+        guard let absoluteURL = self.absoluteURL(from: uri, forOriginURL: originURL) else { return line }
+        guard let reverseProxyURL = self.reverseProxyURL(from: absoluteURL) else { return line }
+        
+        return uriPattern.stringByReplacingMatches(in: line, options: [], range: lineRange, withTemplate: "URI=\"\(reverseProxyURL.absoluteString)\"")
     }
-
-    return URL(string: scheme + "://" + host + path)?.standardized
-  }
-
-
-  // MARK: Caching
-
-  private func cachedData(for resourceURL: URL) -> Data? {
-    let key = self.cacheKey(for: resourceURL)
-    return self.cache.object(forKey: key) as? Data
-  }
-
-  private func saveCacheData(_ data: Data, for resourceURL: URL) {
-    let key = self.cacheKey(for: resourceURL)
-    self.cache.setObject(data, forKey: key)
-  }
-
-  private func cacheKey(for resourceURL: URL) -> String {
-    return resourceURL.absoluteString.data(using: .utf8)!.base64EncodedString()
-  }
+    
+    private func absoluteURL(from line: String, forOriginURL originURL: URL) -> URL? {
+        guard ["m3u8", "ts"].contains(originURL.pathExtension) else { return nil }
+        
+        if line.hasPrefix("http://") || line.hasPrefix("https://") {
+            return URL(string: line)
+        }
+        
+        guard let scheme = originURL.scheme, let host = originURL.host else { return nil }
+        
+        let path: String
+        if line.hasPrefix("/") {
+            path = line
+        } else {
+            path = originURL.deletingLastPathComponent().appendingPathComponent(line).path
+        }
+        
+        return URL(string: scheme + "://" + host + path)?.standardized
+    }
+    
+    
+    // MARK: Caching
+    
+    private func cachedData(for resourceURL: URL) -> Data? {
+        let key = self.cacheKey(for: resourceURL)
+        return self.cache.object(forKey: key) as? Data
+    }
+    
+    private func saveCacheData(_ data: Data, for resourceURL: URL) {
+        let key = self.cacheKey(for: resourceURL)
+        self.cache.setObject(data, forKey: key)
+    }
+    
+    private func cacheKey(for resourceURL: URL) -> String {
+        return resourceURL.absoluteString.data(using: .utf8)!.base64EncodedString()
+    }
 }

--- a/Sources/HLSCachingReverseProxyServer/HLSCachingReverseProxyServer.swift
+++ b/Sources/HLSCachingReverseProxyServer/HLSCachingReverseProxyServer.swift
@@ -9,6 +9,8 @@ open class HLSCachingReverseProxyServer {
     private let urlSession: URLSession
     private let cache: PINCaching
 
+    private let uriPattern = try! NSRegularExpression(pattern: "URI=\"(.*)\"")
+
     private(set) var port: Int?
 
     open var cacheKeyHandler: ((URL) -> String?)?
@@ -148,7 +150,6 @@ open class HLSCachingReverseProxyServer {
     }
 
     private func lineByReplacingURI(line: String, forOriginURL originURL: URL) -> String {
-        let uriPattern = try! NSRegularExpression(pattern: "URI=\"(.*)\"")
         let lineRange = NSMakeRange(0, line.count)
         guard let result = uriPattern.firstMatch(in: line, options: [], range: lineRange) else { return line }
 


### PR DESCRIPTION
Lots of changes in `HLSCachingReverseProxyServer.swift` but it's mainly formatting.

Only 2 essential changes:
1. Fix a bug when using the disk cache (`PINDiskCache`): urls of segments of our videos are used to generate a filename to store on the disk, but these urls are too long as they contain a token which is a large string. Now we generate a MD5 from url to get a shorter string (instead of an encoded base64 string).
2. In the `cacheKey` method, add the ability for the caller to provide the cache key through `cacheKeyHandler` closure. 

Finally, we only use `2.` from the caller side, but `1.` is left in case it's used in the future.

Other noticeable changes:
- Use a specific version of `GCDWebServer` supporting SPM (branch `swift-package-manager`)
- Use Swift 5.7 in `Package.swift`, remove macOS and tvOS support as it was bringing errors from the app side
- Add `GCDWebServer` and `PINCache` in `Package.swift` to fix dependencies errors
- Remove `Nimble` dependency as it was duplicated from the app side